### PR TITLE
Invert coordinates in Tangram sample

### DIFF
--- a/tangram/index.html
+++ b/tangram/index.html
@@ -29,7 +29,7 @@
             attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors'
         });
         tangramLayer.addTo(map);
-        map.setView([-0.15, 51.5], 15);
+        map.setView([51.5, -0.15], 15);
     </script>
 
   </body>


### PR DESCRIPTION
Fix the fact that demo zooms in middle of Indian Ocean instead of Europe (lat, lon coordinates order issue)